### PR TITLE
Change category "file_metadata" to "data_file"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
     -   repo: git@github.com:Yelp/detect-secrets
-        rev: v0.13.1
+        rev: v1.5.0
         hooks:
         -   id: detect-secrets
             args: ['--baseline', '.secrets.baseline']
     -   repo: https://github.com/pre-commit/pre-commit-hooks
-        rev: v2.5.0
+        rev: v4.6.0
         hooks:
         -   id: trailing-whitespace
         -   id: end-of-file-fixer

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,127 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {},
+  "generated_at": "2024-07-01T21:35:12Z"
+}

--- a/gdcdictionary/schemas/aligned_reads_file.yaml
+++ b/gdcdictionary/schemas/aligned_reads_file.yaml
@@ -107,6 +107,11 @@ properties:
     #   - Amplicon
     #   - Other
 
+  file_url:
+    description: >
+      The URL of the file if it does not have a data GUID or object_id.
+    type: string
+
   object_ids:
     description: The list of file identifiers (URLs, DRS URIs, or data GUIDs, etc.) for the file(s), if applicable.
     type: array

--- a/gdcdictionary/schemas/aligned_reads_file.yaml
+++ b/gdcdictionary/schemas/aligned_reads_file.yaml
@@ -54,7 +54,7 @@ uniqueKeys:
   - [ project_id, submitter_id ]
 
 properties:
-  $ref: "_definitions.yaml#/ubiquitous_properties"
+  $ref: "_definitions.yaml#/data_file_properties"
 
   alignment_workflow_type:
     description: The workflow used to align the sequencing reads, e.g., STAR, BWA-aln, BWA-mem, spinakker, etc.

--- a/gdcdictionary/schemas/aligned_reads_file.yaml
+++ b/gdcdictionary/schemas/aligned_reads_file.yaml
@@ -48,6 +48,9 @@ links:
 required:
   - type
   - submitter_id
+  - data_category
+  - data_type
+  - data_format
 
 uniqueKeys:
   - [ id ]

--- a/gdcdictionary/schemas/aligned_reads_file.yaml
+++ b/gdcdictionary/schemas/aligned_reads_file.yaml
@@ -120,5 +120,9 @@ properties:
 
   read_groups:
     $ref: "_definitions.yaml#/to_many"
+
+  unaligned_reads_files:
+    $ref: "_definitions.yaml#/to_many"
+
   core_metadata_collections:
     $ref: "_definitions.yaml#/to_many"

--- a/gdcdictionary/schemas/aligned_reads_file.yaml
+++ b/gdcdictionary/schemas/aligned_reads_file.yaml
@@ -4,11 +4,11 @@ id: "aligned_reads_file"
 title: Aligned Reads File
 type: object
 namespace: https://imaging-hub.data-commons.org
-category: file_metadata
+category: data_file
 program: '*'
 project: '*'
 description: >
-  Data file containing aligned reads, e.g., a BAM file. 
+  Data file containing aligned reads, e.g., a BAM file.
 additionalProperties: false
 submittable: true
 validators: null

--- a/gdcdictionary/schemas/aligned_reads_index_file.yaml
+++ b/gdcdictionary/schemas/aligned_reads_index_file.yaml
@@ -64,6 +64,11 @@ properties:
       $ref: "_terms.yaml#/data_format"
     type: string
 
+  file_url:
+    description: >
+      The URL of the file if it does not have a data GUID or object_id.
+    type: string
+
   object_ids:
     description: The list of file identifiers (URLs, DRS URIs, or data GUIDs, etc.) for the file(s), if applicable.
     type: array

--- a/gdcdictionary/schemas/aligned_reads_index_file.yaml
+++ b/gdcdictionary/schemas/aligned_reads_index_file.yaml
@@ -44,7 +44,7 @@ uniqueKeys:
   - [ project_id, submitter_id ]
 
 properties:
-  $ref: "_definitions.yaml#/ubiquitous_properties"
+  $ref: "_definitions.yaml#/data_file_properties"
 
   data_category:
     term:

--- a/gdcdictionary/schemas/aligned_reads_index_file.yaml
+++ b/gdcdictionary/schemas/aligned_reads_index_file.yaml
@@ -4,7 +4,7 @@ id: "aligned_reads_index_file"
 title: Aligned Reads Index File
 type: object
 namespace: https://imaging-hub.data-commons.org
-category: file_metadata
+category: data_file
 program: '*'
 project: '*'
 description: "Data file containing the index for a set of aligned reads, e.g., a BAI file."
@@ -34,7 +34,7 @@ links:
     target_type: core_metadata_collection
     multiplicity: many_to_many
     required: false
-    
+
 required:
   - type
   - submitter_id
@@ -60,7 +60,7 @@ properties:
     term:
       $ref: "_terms.yaml#/data_format"
     type: string
-      
+
   object_ids:
     description: The list of file identifiers (URLs, DRS URIs, or data GUIDs, etc.) for the file(s), if applicable.
     type: array

--- a/gdcdictionary/schemas/aligned_reads_index_file.yaml
+++ b/gdcdictionary/schemas/aligned_reads_index_file.yaml
@@ -38,6 +38,9 @@ links:
 required:
   - type
   - submitter_id
+  - data_category
+  - data_type
+  - data_format
 
 uniqueKeys:
   - [ id ]

--- a/gdcdictionary/schemas/clinical_file.yaml
+++ b/gdcdictionary/schemas/clinical_file.yaml
@@ -4,7 +4,7 @@ id: "clinical_file"
 title: Clinical File
 type: object
 namespace: https://data.midrc.org
-category: file_metadata
+category: data_file
 program: '*'
 project: '*'
 description: >

--- a/gdcdictionary/schemas/clinical_file.yaml
+++ b/gdcdictionary/schemas/clinical_file.yaml
@@ -48,6 +48,9 @@ links:
 required:
   - submitter_id
   - type
+  - data_category
+  - data_type
+  - data_format
 
 uniqueKeys:
   - [ id ]

--- a/gdcdictionary/schemas/clinical_file.yaml
+++ b/gdcdictionary/schemas/clinical_file.yaml
@@ -76,6 +76,11 @@ properties:
     description: "The text term describing the file format of the supplementary file, for example, PDF, XLSX, JPEG, PNG, TSV, etc."
     type: string
 
+  file_url:
+    description: >
+      The URL of the file if it does not have a data GUID or object_id.
+    type: string
+
   object_ids:
     description: The list of file identifiers (URLs, DRS URIs, or data GUIDs, etc.) for the file(s), if applicable.
     type: array

--- a/gdcdictionary/schemas/clinical_file.yaml
+++ b/gdcdictionary/schemas/clinical_file.yaml
@@ -45,10 +45,6 @@ links:
         multiplicity: many_to_one
         required: false
 
-uniqueKeys:
-  - [id]
-  - [project_id, submitter_id]
-
 required:
   - submitter_id
   - type
@@ -58,7 +54,7 @@ uniqueKeys:
   - [ project_id, submitter_id ]
 
 properties:
-  $ref: "_definitions.yaml#/ubiquitous_properties"
+  $ref: "_definitions.yaml#/data_file_properties"
 
   file_description:
     description: >

--- a/gdcdictionary/schemas/image_annotation.yaml
+++ b/gdcdictionary/schemas/image_annotation.yaml
@@ -65,6 +65,9 @@ links:
 required:
   - submitter_id
   - type
+  - data_category
+  - data_type
+  - data_format
 
 uniqueKeys:
   - [id]

--- a/gdcdictionary/schemas/image_annotation.yaml
+++ b/gdcdictionary/schemas/image_annotation.yaml
@@ -25,7 +25,7 @@ links:
     required: true
     subgroup:
       - name: core_metadata_collections
-        backref: image_files
+        backref: annotations
         label: data_from
         target_type: core_metadata_collection
         multiplicity: many_to_one

--- a/gdcdictionary/schemas/image_annotation.yaml
+++ b/gdcdictionary/schemas/image_annotation.yaml
@@ -115,6 +115,21 @@ properties:
         - negative
         - typical
 
+  data_category:
+    term:
+      $ref: "_terms.yaml#/data_category"
+    type: string
+
+  data_type:
+    term:
+      $ref: "_terms.yaml#/data_type"
+    type: string
+
+  data_format:
+    term:
+      $ref: "_terms.yaml#/data_format"
+    type: string
+
   instance_uids:
     description: Used to denote that this annotation applies only to specific images (image instances) in a series.  When absent, the annotation when referencing an imaging series node applies to the entire imaging series.
     type: array

--- a/gdcdictionary/schemas/image_annotation.yaml
+++ b/gdcdictionary/schemas/image_annotation.yaml
@@ -71,8 +71,7 @@ uniqueKeys:
   - [project_id, submitter_id]
 
 properties:
-
-  $ref: "_definitions.yaml#/ubiquitous_properties"
+  $ref: "_definitions.yaml#/data_file_properties"
 
   airspace_disease_grading:
     description: Values are extracted from the annotation file midrc_mdai_chestxr. Accepted values are "mild" opacities (1-2 lung zones), "moderate" opacities (3-4 lung zones), and "severe" opacities (>4 lung zones).

--- a/gdcdictionary/schemas/image_annotation.yaml
+++ b/gdcdictionary/schemas/image_annotation.yaml
@@ -5,7 +5,7 @@ title: Image Annotation
 type: object
 nodeTerms: null
 namespace: https://imaging-hub.data-commons.org
-category: file_metadata
+category: data_file
 program: '*'
 project: '*'
 description: Files containing information describing characteristics of imaging studies, series and instances (e.g., segmentations, bounding boxes, feature labels) and inferences based on those characteristics (e.g., predicted diagnoses). Annotations may be recorded in the course of clinical care or retrospectively for purposes of research (e.g., imaging annotations from PACS or retrospective labeling tools). Please refer to https://midrc.org/annotations to learn more about a particular batch of annotations.
@@ -100,7 +100,7 @@ properties:
         - midrc_lung_measures
         - midrc_mdai_chestxr
         - mRALE_Mastermind_Challenge
-        - SIFT        
+        - SIFT
 
   class_covid19_pneumonia:
     description: Values are extracted from the annotation file midrc_mdai_chestxr; Accepted values include "typical" appearance, which is multifocal bilateral, peripheral opacities, or opacities with rounded morphology, lower lung-predominant distribution;  "indeterminate" appearance, which is absence of typical findings and unilateral, central or upper lung predominant distribution of airspace disease; "atypical" appearance, which is pneumothorax or pleural effusion, pulmonary edema, lobar consolidation, solitary lung nodule, or mass diffuse tiny nodules cavity; "negative" for pneumonia, which is no lung opacities.

--- a/gdcdictionary/schemas/image_annotation.yaml
+++ b/gdcdictionary/schemas/image_annotation.yaml
@@ -24,6 +24,12 @@ links:
   - exclusive: false
     required: true
     subgroup:
+      - name: core_metadata_collections
+        backref: image_files
+        label: data_from
+        target_type: core_metadata_collection
+        multiplicity: many_to_one
+        required: false
       - name: datasets
         backref: annotations
         label: related_to
@@ -161,4 +167,7 @@ properties:
 
   image_files:
     description: The submitter_id or id of the image file this annotation relates to, i.e., a link to a record in the parent node.
+    $ref: "_definitions.yaml#/to_one"
+
+  core_metadata_collections:
     $ref: "_definitions.yaml#/to_one"

--- a/gdcdictionary/schemas/image_file.yaml
+++ b/gdcdictionary/schemas/image_file.yaml
@@ -86,6 +86,11 @@ properties:
       $ref: "_terms.yaml#/experimental_strategy"
     type: string
 
+  file_url:
+    description: >
+      The URL of the file if it does not have a data GUID or object_id.
+    type: string
+
   image_quality:
     description: >
       Good, poor, or average image quality

--- a/gdcdictionary/schemas/image_file.yaml
+++ b/gdcdictionary/schemas/image_file.yaml
@@ -4,7 +4,7 @@ id: "image_file"
 title: Image File
 type: object
 namespace: https://imaging-hub.data-commons.org
-category: file_metadata
+category: data_file
 program: '*'
 project: '*'
 description: >
@@ -107,12 +107,12 @@ properties:
     description: >
       order number for this image or other content.
     type: integer
-    
+
   file_phase:
     description: >
-      The image file's data release Phase for a particular study. 
-    type: integer 
-    
+      The image file's data release Phase for a particular study.
+    type: integer
+
   subjects:
     $ref: "_definitions.yaml#/to_one"
 

--- a/gdcdictionary/schemas/image_file.yaml
+++ b/gdcdictionary/schemas/image_file.yaml
@@ -56,6 +56,9 @@ uniqueKeys:
 required:
   - type
   - submitter_id
+  - data_category
+  - data_type
+  - data_format
 
 properties:
   $ref: "_definitions.yaml#/data_file_properties"

--- a/gdcdictionary/schemas/image_file.yaml
+++ b/gdcdictionary/schemas/image_file.yaml
@@ -30,6 +30,12 @@ links:
         target_type: core_metadata_collection
         multiplicity: many_to_one
         required: false
+      - name: datasets
+        backref: image_files
+        label: data_from
+        target_type: dataset
+        multiplicity: many_to_one
+        required: false
       - name: subjects
         backref: image_files
         label: data_from
@@ -48,6 +54,7 @@ links:
         target_type: imaging_study
         multiplicity: many_to_one
         required: false
+
 
 uniqueKeys:
   - [id]
@@ -121,7 +128,16 @@ properties:
       The image file's data release Phase for a particular study.
     type: integer
 
+  datasets:
+    $ref: "_definitions.yaml#/to_one"
+
   subjects:
+    $ref: "_definitions.yaml#/to_one"
+
+  imaging_studies:
+    $ref: "_definitions.yaml#/to_one"
+
+  imaging_series:
     $ref: "_definitions.yaml#/to_one"
 
   core_metadata_collections:

--- a/gdcdictionary/schemas/image_file.yaml
+++ b/gdcdictionary/schemas/image_file.yaml
@@ -58,7 +58,7 @@ required:
   - submitter_id
 
 properties:
-  $ref: "_definitions.yaml#/ubiquitous_properties"
+  $ref: "_definitions.yaml#/data_file_properties"
 
   type:
     enum: [ "imaging_file" ]

--- a/gdcdictionary/schemas/imaging_series.yaml
+++ b/gdcdictionary/schemas/imaging_series.yaml
@@ -75,6 +75,20 @@ properties:
     description: A URL where the imaging series can be viewed.
     type: string
 
+  file_names:
+    description: >
+      The file names of any data files associated with this imaging series.
+    type: array
+    items:
+      type: string
+
+  file_urls:
+    description: >
+      The URLs of any data files associated with this imaging series.
+    type: array
+    items:
+      type: string
+
   MagneticFieldStrength:
     description: (0018, 0087) Magnetic Field Strength
     type: string

--- a/gdcdictionary/schemas/subject.yaml
+++ b/gdcdictionary/schemas/subject.yaml
@@ -41,10 +41,6 @@ properties:
 
   $ref: "_definitions.yaml#/ubiquitous_properties"
 
-#   PatientID: # use subject.submitter_id
-#     description: (0010,0020) A unique identifier for the patient.
-#     type: string
-
   age_at_index:
     description: The study participant's age, in years, at the index event. The index event is determined by the data submitter and used as an anchor date for all temporal variables. Note that an age of 0 indicates a participant who is younger than 1 year old. For participants with ages greater than 89 years, please use the property 'age_at_index_gt89'.
     type: number
@@ -108,6 +104,13 @@ properties:
   site_id:
     description: A de-identified code used to classify a case as part of a specific data submission.
     type: string
+
+  # subject_id: # just use submitter_id?
+  #   description: (0010,0020) A unique identifier for the patient.
+  #   type: string    
+  #  PatientID: # use subject.submitter_id
+  #    description: (0010,0020) A unique identifier for the patient.
+  #    type: string
 
   vital_status:
     term:

--- a/gdcdictionary/schemas/unaligned_reads_file.yaml
+++ b/gdcdictionary/schemas/unaligned_reads_file.yaml
@@ -41,6 +41,9 @@ links:
 required:
   - type
   - submitter_id
+  - data_category
+  - data_type
+  - data_format
 
 uniqueKeys:
   - [ id ]

--- a/gdcdictionary/schemas/unaligned_reads_file.yaml
+++ b/gdcdictionary/schemas/unaligned_reads_file.yaml
@@ -47,7 +47,7 @@ uniqueKeys:
   - [ project_id, submitter_id ]
 
 properties:
-  $ref: "_definitions.yaml#/ubiquitous_properties"
+  $ref: "_definitions.yaml#/data_file_properties"
 
   data_category:
     term:

--- a/gdcdictionary/schemas/unaligned_reads_file.yaml
+++ b/gdcdictionary/schemas/unaligned_reads_file.yaml
@@ -4,7 +4,7 @@ id: "unaligned_reads_file"
 title: Unaligned Reads File
 type: object
 namespace: https://imaging-hub.data-commons.org
-category: file_metadata
+category: data_file
 program: '*'
 project: '*'
 description: "Data file containing unaligned reads, e.g., a FASTQ file."

--- a/gdcdictionary/schemas/unaligned_reads_file.yaml
+++ b/gdcdictionary/schemas/unaligned_reads_file.yaml
@@ -72,6 +72,11 @@ properties:
       $ref: "_terms.yaml#/experimental_strategy"
     type: string
 
+  file_url:
+    description: >
+      The URL of the file if it does not have a data GUID or object_id.
+    type: string
+
   object_ids:
     description: The list of file identifiers (URLs, DRS URIs, or data GUIDs, etc.) for the file(s), if applicable.
     type: array

--- a/gdcdictionary/schemas/variant_call_file.yaml
+++ b/gdcdictionary/schemas/variant_call_file.yaml
@@ -79,6 +79,11 @@ properties:
       $ref: "_terms.yaml#/experimental_strategy"
     type: string
 
+  file_url:
+    description: >
+      The URL of the file if it does not have a data GUID or object_id.
+    type: string
+
   object_ids:
     description: The list of file identifiers (URLs, DRS URIs, or data GUIDs, etc.) for the file(s), if applicable.
     type: array

--- a/gdcdictionary/schemas/variant_call_file.yaml
+++ b/gdcdictionary/schemas/variant_call_file.yaml
@@ -48,6 +48,9 @@ links:
 required:
   - type
   - submitter_id
+  - data_category
+  - data_type
+  - data_format
 
 uniqueKeys:
   - [ id ]

--- a/gdcdictionary/schemas/variant_call_file.yaml
+++ b/gdcdictionary/schemas/variant_call_file.yaml
@@ -54,7 +54,7 @@ uniqueKeys:
   - [ project_id, submitter_id ]
 
 properties:
-  $ref: "_definitions.yaml#/ubiquitous_properties"
+  $ref: "_definitions.yaml#/data_file_properties"
 
   data_category:
     term:

--- a/gdcdictionary/schemas/variant_call_file.yaml
+++ b/gdcdictionary/schemas/variant_call_file.yaml
@@ -4,7 +4,7 @@ id: "variant_call_file"
 title: Variant Call File
 type: object
 namespace: https://imaging-hub.data-commons.org
-category: file_metadata
+category: data_file
 program: '*'
 project: '*'
 description: >


### PR DESCRIPTION


Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes

### Bug Fixes
- Change category "file_metadata" to "data_file" because the portal requires at least 1 node of category "data_file"

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
